### PR TITLE
do not register html5-boilerplate if Compass is not defined

### DIFF
--- a/lib/html5-boilerplate.rb
+++ b/lib/html5-boilerplate.rb
@@ -1,4 +1,4 @@
-Compass::Frameworks.register("html5-boilerplate", :path => "#{File.dirname(__FILE__)}/..")
+Compass::Frameworks.register("html5-boilerplate", :path => "#{File.dirname(__FILE__)}/..") if defined?(Compass)
 
 if defined?(ActionController)
   require File.join(File.dirname(__FILE__), 'app', 'helpers', 'html5_boilerplate_helper')


### PR DESCRIPTION
short 'why':
in production we do not need :assets group but we need html5-boilerplate's helper methods
long 'why': http://kucaahbe.github.com/2011/08/30/html5-boilerplate-and-rails3.1.html
