### PR TITLE
Adding require to compass-h5bp

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ Use this if you're not using Rails, but still want compass and the html5-boilerp
 It will create a simplified index.html (with haml source), but without the nice Rails helpers.
 
     gem install html5-boilerplate
-    compass create my_project -r compass-h5bp -r html5-boilerplate -u html5-boilerplate --javascripts-dir js --css-dir css
+    compass create my_project -r html5-boilerplate -u html5-boilerplate --javascripts-dir js --css-dir css
 
 The `--javascripts-dir` and `--css-dir` flags are to keep consistent with the original project layout.
 If you omit them, be sure to edit your javascript and style tags accordingly in index.html.

--- a/lib/html5-boilerplate.rb
+++ b/lib/html5-boilerplate.rb
@@ -1,3 +1,4 @@
+require 'compass-h5bp'
 Compass::Frameworks.register("html5-boilerplate", :path => "#{File.dirname(__FILE__)}/..")
 
 if defined?(ActionController)


### PR DESCRIPTION
Adding the require directly to the html5-boilerplate.rb file to remove the need to add a second require to `compass init` or `compass create`
